### PR TITLE
notoフォントの展開とworkへのフォントキャッシュ保持

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,27 @@ RUN update-locale en_US.UTF-8
 RUN apt-get install -y git-core curl
 
 # install Re:VIEW environment
+# install font map of noto for dvipdfmx
+ADD https://kmuto.jp/debian/noto/noto-map.tgz /tmp/noto-map.tgz
+RUN mkdir -p /usr/share/texlive/texmf-dist/fonts/map/dvipdfmx/ptex-fontmaps && cd /usr/share/texlive/texmf-dist/fonts/map/dvipdfmx/ptex-fontmaps && tar zxvf /tmp/noto-map.tgz && rm /tmp/noto-map.tgz
+
+# set cache folder to work folder
+RUN mkdir -p /etc/texmf/texmf.d && echo "TEXMFVAR=/work/.texmf-var" > /etc/texmf/texmf.d/99local.cnf
+
 ## NOTE noto serif is experimental. can't install via fonts-noto-cjk now.
-RUN curl -sL -o /tmp/noto.deb https://kmuto.jp/debian/noto/fonts-noto-cjk_1.004+repack3-1~exp1_all.deb && dpkg -i /tmp/noto.deb && rm /tmp/noto.deb && \
-    apt-get install -y texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra && \
+ADD http://kmuto.jp/debian/noto/fonts-noto-cjk_1.004+repack3-1~exp1_all.deb /tmp/noto.deb
+RUN dpkg -i /tmp/noto.deb && rm /tmp/noto.deb
+
+RUN apt-get install -y --no-install-recommends texlive-lang-japanese texlive-fonts-recommended texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern fonts-texgyre tex-gyre texlive-pictures && \
     apt-get install -y --no-install-recommends ghostscript gsfonts zip ruby-zip ruby-nokogiri ruby-mecab mecab mecab-ipadic-utf8 poppler-data && \
     kanji-config-updmap ipaex && \
+    apt-get -y --no-install-recommends upgrade && \
     apt-get clean
-ADD ./noto-font.map /etc/texmf
+
+# use noto for uplatex
+RUN kanji-config-updmap-sys noto
+
+# setup Re:VIEW
 RUN gem install review review-peg bundler rake --no-rdoc --no-ri
 
 # install node.js environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,13 @@ RUN update-locale en_US.UTF-8
 RUN apt-get install -y git-core curl
 
 # install Re:VIEW environment
-RUN apt-get install -y texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra && kanji-config-updmap ipaex
-RUN apt-get install -y --no-install-recommends zip
+## NOTE noto serif is experimental. can't install via fonts-noto-cjk now.
+RUN curl -sL -o /tmp/noto.deb https://kmuto.jp/debian/noto/fonts-noto-cjk_1.004+repack3-1~exp1_all.deb && dpkg -i /tmp/noto.deb && rm /tmp/noto.deb && \
+    apt-get install -y texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra && \
+    apt-get install -y --no-install-recommends ghostscript gsfonts zip ruby-zip ruby-nokogiri ruby-mecab mecab mecab-ipadic-utf8 poppler-data && \
+    kanji-config-updmap ipaex && \
+    apt-get clean
+ADD ./noto-font.map /etc/texmf
 RUN gem install review review-peg bundler rake --no-rdoc --no-ri
 
 # install node.js environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get install -y git-core curl
 ADD https://kmuto.jp/debian/noto/noto-map.tgz /tmp/noto-map.tgz
 RUN mkdir -p /usr/share/texlive/texmf-dist/fonts/map/dvipdfmx/ptex-fontmaps && cd /usr/share/texlive/texmf-dist/fonts/map/dvipdfmx/ptex-fontmaps && tar zxvf /tmp/noto-map.tgz && rm /tmp/noto-map.tgz
 
-# set cache folder to work folder
-RUN mkdir -p /etc/texmf/texmf.d && echo "TEXMFVAR=/work/.texmf-var" > /etc/texmf/texmf.d/99local.cnf
+# set cache folder to work folder (disabled by default)
+# RUN mkdir -p /etc/texmf/texmf.d && echo "TEXMFVAR=/work/.texmf-var" > /etc/texmf/texmf.d/99local.cnf
 
 ## NOTE noto serif is experimental. can't install via fonts-noto-cjk now.
 ADD http://kmuto.jp/debian/noto/fonts-noto-cjk_1.004+repack3-1~exp1_all.deb /tmp/noto.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,33 +4,16 @@ MAINTAINER vvakame
 ENV LANG en_US.UTF-8
 
 # setup
-RUN apt-get update
-RUN apt-get install -y locales
+RUN apt-get update && apt-get install -y locales git-core curl
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
-RUN locale-gen en_US.UTF-8
-RUN update-locale en_US.UTF-8
-RUN apt-get install -y git-core curl
+RUN locale-gen en_US.UTF-8 && update-locale en_US.UTF-8
 
 # install Re:VIEW environment
-# install font map of noto for dvipdfmx
-ADD https://kmuto.jp/debian/noto/noto-map.tgz /tmp/noto-map.tgz
-RUN mkdir -p /usr/share/texlive/texmf-dist/fonts/map/dvipdfmx/ptex-fontmaps && cd /usr/share/texlive/texmf-dist/fonts/map/dvipdfmx/ptex-fontmaps && tar zxvf /tmp/noto-map.tgz && rm /tmp/noto-map.tgz
-
-# set cache folder to work folder (disabled by default)
-# RUN mkdir -p /etc/texmf/texmf.d && echo "TEXMFVAR=/work/.texmf-var" > /etc/texmf/texmf.d/99local.cnf
-
-## NOTE noto serif is experimental. can't install via fonts-noto-cjk now.
-ADD http://kmuto.jp/debian/noto/fonts-noto-cjk_1.004+repack3-1~exp1_all.deb /tmp/noto.deb
-RUN dpkg -i /tmp/noto.deb && rm /tmp/noto.deb
-
-RUN apt-get install -y --no-install-recommends texlive-lang-japanese texlive-fonts-recommended texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern fonts-texgyre tex-gyre texlive-pictures && \
-    apt-get install -y --no-install-recommends ghostscript gsfonts zip ruby-zip ruby-nokogiri ruby-mecab mecab mecab-ipadic-utf8 poppler-data && \
+RUN apt-get install -y --no-install-recommends \
+      texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern tex-gyre fonts-texgyre texlive-pictures \
+      ghostscript gsfonts zip ruby-zip ruby-nokogiri mecab ruby-mecab mecab-ipadic-utf8 poppler-data && \
     kanji-config-updmap ipaex && \
-    apt-get -y --no-install-recommends upgrade && \
     apt-get clean
-
-# use noto for uplatex
-RUN kanji-config-updmap-sys noto
 
 # setup Re:VIEW
 RUN gem install review review-peg bundler rake --no-rdoc --no-ri
@@ -39,3 +22,20 @@ RUN gem install review review-peg bundler rake --no-rdoc --no-ri
 RUN apt-get install -y gnupg
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 RUN apt-get install -y nodejs
+
+## NOTE noto serif is experimental. can't install via fonts-noto-cjk now.
+#RUN echo "deb http://ftp.jp.debian.org/debian/ stretch-backports main" >> /etc/apt/sources.list
+#RUN apt-get update && apt-get -y install fonts-noto-cjk/stretch-backports
+ADD https://kmuto.jp/debian/noto/fonts-noto-cjk_1.004+repack3-1~exp1_all.deb /tmp/noto.deb
+RUN dpkg -i /tmp/noto.deb && rm /tmp/noto.deb
+
+## install font map of noto for dvipdfmx
+ADD https://kmuto.jp/debian/noto/noto-map.tgz /tmp/noto-map.tgz
+RUN tar Cxvf /usr/share/texlive/texmf-dist/fonts/map/dvipdfmx/ptex-fontmaps \
+    /tmp/noto-map.tgz && rm /tmp/noto-map.tgz
+
+## use noto for uplatex
+RUN texhash && kanji-config-updmap-sys noto
+
+## set cache folder to work folder (disabled by default)
+# RUN mkdir -p /etc/texmf/texmf.d && echo "TEXMFVAR=/work/.texmf-var" > /etc/texmf/texmf.d/99local.cnf

--- a/noto-font.map
+++ b/noto-font.map
@@ -1,0 +1,8 @@
+uphminl-h unicode NotoSerifCJK-Light.ttc
+uphminr-h unicode NotoSerifCJK-Regular.ttc
+uphminb-h unicode NotoSerifCJK-Bold.ttc
+uphgothl-h unicode NotoSansCJK-Light.ttc
+uphgothr-h unicode NotoSansCJK-Regular.ttc
+uphgothb-h unicode NotoSansCJK-Bold.ttc
+uphgotheb-h unicode NotoSansCJK-Black.ttc
+uphmgothr-h unicode NotoSansCJK-Black.ttc


### PR DESCRIPTION
- installするdebを、Re:VIEW挙動に問題ない範囲でなるべく削ってみました。
- zipはruby-zipで代替できるようにしたはずなので除きました。でも依存関係で結局入るかも。
- IPAexをベースにマップファイルを作成し、uplatex横書きにおいてnotoがデフォルトで使われるようにしました。
- stretchはまだテスト段階なので、念のために更新のためのupgradeを最後に実行するようにしました。

- run時のディレクトリ名を制限することになるのでよくないかもしれないのですが、マウントされた/workに.texmf-varディレクトリを作るように設定してみました。このディレクトリには自動生成されるpkフォントファイルが置かれます。何度もビルド実行する際にクリアされてまた自動生成されるのが辛い、と@takahashimさんが言ってた気がしたので。フォールバックがないので、/work以外の名前でマウントされると、まずいことが起きそうです。