### PR TITLE
textlintを入れる

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ RUN apt-get update && \
       nodejs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    npm install -g yarn
+    npm install -g yarn && \
+    npm install --unsafe-perm -g textlint textlint-plugin-review textlint-rule-prh textlint-rule-preset-jtf-style
 
 ## NOTE noto serif is experimental. can't install via fonts-noto-cjk now.
 #RUN echo "deb http://ftp.jp.debian.org/debian/ stretch-backports main" >> /etc/apt/sources.list


### PR DESCRIPTION
こんにちは、Re:VIEWでPDF/ePubを生成するのに、こちらのDockerイメージ使わせていただいております。ありがとうございます！

単にPDF/ePubを生成するだけでなく、テストも回したいと考えています。せっかくなら同じコンテナに関連するチェックツール(textlint)も入っていると嬉しいなと思ったのですが、いかがでしょうか。

Re:VIEWのソースが入っているディレクトリに、以下のような内容の`.textlintrc`を入れておき、

```
{
  "plugins": {
    "review"
  },
  "rules": {
    "preset-jtf-style": true,
    "prh": {
      "rulePaths": [
        "/work/prh-rules/review.yml"
      ]
    }
  }
}
```

以下のコマンドのようにdockerコンテナを起動すると、textlintでチェックできます。

```
docker run --rm -v $(pwd):/work review-test /bin/bash -c "cd /work && textlint -f pretty-error *.re"
```

(マージしていただけるようなら、READMEにこのコマンドなど使い方も追加します)