### PR TITLE
enable-to-build-native-extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern tex-gyre fonts-texgyre texlive-pictures \
       ghostscript gsfonts zip ruby-zip ruby-nokogiri mecab ruby-mecab mecab-ipadic-utf8 poppler-data cm-super \
+      ruby-dev build-essential \
       graphviz gnuplot python-blockdiag python-aafigure && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/review-2.3/Dockerfile
+++ b/review-2.3/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern tex-gyre fonts-texgyre texlive-pictures \
       ghostscript gsfonts zip ruby-zip ruby-nokogiri mecab ruby-mecab mecab-ipadic-utf8 poppler-data cm-super \
+      ruby-dev build-essential \
       graphviz gnuplot python-blockdiag python-aafigure && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/review-2.4/Dockerfile
+++ b/review-2.4/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern tex-gyre fonts-texgyre texlive-pictures \
       ghostscript gsfonts zip ruby-zip ruby-nokogiri mecab ruby-mecab mecab-ipadic-utf8 poppler-data cm-super \
+      ruby-dev build-essential \
       graphviz gnuplot python-blockdiag python-aafigure && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/review-2.5/Dockerfile
+++ b/review-2.5/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern tex-gyre fonts-texgyre texlive-pictures \
       ghostscript gsfonts zip ruby-zip ruby-nokogiri mecab ruby-mecab mecab-ipadic-utf8 poppler-data cm-super \
+      ruby-dev build-essential \
       graphviz gnuplot python-blockdiag python-aafigure && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/review-3.0/Dockerfile
+++ b/review-3.0/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern tex-gyre fonts-texgyre texlive-pictures \
       ghostscript gsfonts zip ruby-zip ruby-nokogiri mecab ruby-mecab mecab-ipadic-utf8 poppler-data cm-super \
+      ruby-dev build-essential \
       graphviz gnuplot python-blockdiag python-aafigure && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/review-3.1/Dockerfile
+++ b/review-3.1/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern tex-gyre fonts-texgyre texlive-pictures \
       ghostscript gsfonts zip ruby-zip ruby-nokogiri mecab ruby-mecab mecab-ipadic-utf8 poppler-data cm-super \
+      ruby-dev build-essential \
       graphviz gnuplot python-blockdiag python-aafigure && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
md2review とかが使えるようになる

イメージサイズは15MBくらい増えるだけ

docker images | grep review       [4:55:16]
review-build                                             3.1                 383d4ae09918        4 minutes ago       1.96GB
vvakame/review                                           3.1                 e78ab97266ca        3 weeks ago         1.81GB