### PR TITLE
Debian 10 Buster version for Re:VIEW 3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 LABEL maintainer="vvakame@gmail.com"
 
 ENV REVIEW_VERSION 3.1.0
@@ -46,9 +46,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     npm install -g yarn
 
-# install noto font from backports
-RUN echo "deb http://ftp.jp.debian.org/debian/ stretch-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get -y install fonts-noto-cjk/stretch-backports fonts-noto-cjk-extra/stretch-backports
+# install noto font
+RUN apt-get update && apt-get -y install fonts-noto-cjk-extra
 
 ## install font map of noto for dvipdfmx
 COPY noto/ /usr/share/texlive/texmf-dist/fonts/map/dvipdfmx/ptex-fontmaps/noto/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:buster-slim
 LABEL maintainer="vvakame@gmail.com"
 
-ENV REVIEW_VERSION 3.1.0
+ENV REVIEW_VERSION 3.2.0
 ENV REVIEW_PEG_VERSION 0.2.2
 ENV NODEJS_VERSION 10
 
@@ -22,7 +22,8 @@ RUN apt-get update && \
       texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern tex-gyre fonts-texgyre texlive-pictures texlive-plain-generic \
       ghostscript gsfonts zip ruby-zip ruby-nokogiri mecab ruby-mecab mecab-ipadic-utf8 poppler-data cm-super \
       ruby-dev build-essential \
-      graphviz gnuplot python-blockdiag python-aafigure && \
+      graphviz gnuplot python-blockdiag python-aafigure \
+      mecab-jumandic- mecab-jumandic-utf8- && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 ## if you want to use ipa font instead of noto font, use this settings
@@ -30,8 +31,8 @@ RUN apt-get update && \
 
 # setup Re:VIEW
 RUN gem install bundler rake --no-rdoc --no-ri && \
-    gem install review -v "$REVIEW_VERSION" --no-rdoc --no-ri && \
-    gem install review-peg -v "$REVIEW_PEG_VERSION" --no-rdoc --no-ri
+    gem install review -v "$REVIEW_VERSION" --no-rdoc --no-ri
+#   gem install review-peg -v "$REVIEW_PEG_VERSION" --no-rdoc --no-ri
 
 # install node.js environment
 RUN apt-get update && \
@@ -48,7 +49,9 @@ RUN apt-get update && \
     npm install -g yarn
 
 # install noto font
-RUN apt-get update && apt-get -y install fonts-noto-cjk-extra
+RUN apt-get update && apt-get -y install fonts-noto-cjk-extra && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ## install font map of noto for dvipdfmx
 COPY noto-otc/ /usr/share/texlive/texmf-dist/fonts/map/dvipdfmx/ptex-fontmaps/noto-otc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,12 @@ RUN locale-gen en_US.UTF-8 && update-locale en_US.UTF-8
 # install Re:VIEW environment
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern tex-gyre fonts-texgyre texlive-pictures texlive-plain-generic \
-      ghostscript gsfonts zip ruby-zip ruby-nokogiri mecab ruby-mecab mecab-ipadic-utf8 poppler-data cm-super \
-      ruby-dev build-essential \
+      texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern cm-super tex-gyre fonts-texgyre texlive-pictures texlive-plain-generic \
+      ghostscript gsfonts \
+      zip ruby-zip \
+      ruby-nokogiri mecab ruby-mecab mecab-ipadic-utf8 poppler-data \
       graphviz gnuplot python-blockdiag python-aafigure \
+      ruby-dev build-essential \
       mecab-jumandic- mecab-jumandic-utf8- && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -40,7 +42,7 @@ RUN apt-get update && \
       gnupg && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-RUN curl -sL https://deb.nodesource.com/setup_${NODEJS_VERSION}.x | bash - 
+RUN curl -sL https://deb.nodesource.com/setup_${NODEJS_VERSION}.x | bash -
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       nodejs && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN locale-gen en_US.UTF-8 && update-locale en_US.UTF-8
 # install Re:VIEW environment
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern tex-gyre fonts-texgyre texlive-pictures \
+      texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern tex-gyre fonts-texgyre texlive-pictures texlive-plain-generic \
       ghostscript gsfonts zip ruby-zip ruby-nokogiri mecab ruby-mecab mecab-ipadic-utf8 poppler-data cm-super \
       graphviz gnuplot python-blockdiag python-aafigure && \
     apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,10 +50,10 @@ RUN apt-get update && \
 RUN apt-get update && apt-get -y install fonts-noto-cjk-extra
 
 ## install font map of noto for dvipdfmx
-COPY noto/ /usr/share/texlive/texmf-dist/fonts/map/dvipdfmx/ptex-fontmaps/noto/
+COPY noto-otc/ /usr/share/texlive/texmf-dist/fonts/map/dvipdfmx/ptex-fontmaps/noto-otc/
 
 ## use noto for uplatex
-RUN texhash && kanji-config-updmap-sys noto
+RUN texhash && kanji-config-updmap-sys noto-otc
 
 ## set cache folder to work folder (disabled by default)
 # RUN mkdir -p /etc/texmf/texmf.d && echo "TEXMFVAR=/work/.texmf-var" > /etc/texmf/texmf.d/99local.cnf

--- a/noto-otc/otf-ko-noto-otc.map
+++ b/noto-otc/otf-ko-noto-otc.map
@@ -1,0 +1,12 @@
+
+% CID
+otf-ckmr-h	Identity-H	!HYSMyeongJo-Medium
+otf-ckmr-v	Identity-V	!HYSMyeongJo-Medium
+otf-ckgr-h	Identity-H	!HYGoThic-Medium
+otf-ckgr-v	Identity-V	!HYGoThic-Medium
+
+% Unicode
+otf-ukmr-h	unicode	:1:NotoSerifCJK-Regular.ttc %!DVIPSFB !HYSMyeongJo-Medium-UniKS-UCS2-H
+otf-ukmr-v	unicode	:1:NotoSerifCJK-Regular.ttc -w 1 %!DVIPSFB !HYSMyeongJo-Medium-UniKS-UCS2-V
+otf-ukgr-h	unicode	:1:NotoSansCJK-Medium.ttc %!DVIPSFB !HYGoThic-Medium-UniKS-UCS2-H
+otf-ukgr-v	unicode	:1:NotoSansCJK-Medium.ttc -w 1 %!DVIPSFB !HYGoThic-Medium-UniKS-UCS2-V

--- a/noto-otc/otf-noto-otc.map
+++ b/noto-otc/otf-noto-otc.map
@@ -1,0 +1,80 @@
+
+% TEXT, 90JIS
+hminl-h	H	!Ryumin-Light
+hminl-v	V	!Ryumin-Light
+hminr-h	H	!Ryumin-Light
+hminr-v	V	!Ryumin-Light
+hminb-h	H	!Ryumin-Light,Bold
+hminb-v	V	!Ryumin-Light,Bold
+hgothr-h	H	!GothicBBB-Medium
+hgothr-v	V	!GothicBBB-Medium
+hgothb-h	H	!GothicBBB-Medium,Bold
+hgothb-v	V	!GothicBBB-Medium,Bold
+hgotheb-h	H	!GothicBBB-Medium,Bold
+hgotheb-v	V	!GothicBBB-Medium,Bold
+hmgothr-h	H	!GothicBBB-Medium
+hmgothr-v	V	!GothicBBB-Medium
+
+% TEXT, JIS04
+hminln-h	H	!Ryumin-Light
+hminln-v	V	!Ryumin-Light
+hminrn-h	H	!Ryumin-Light
+hminrn-v	V	!Ryumin-Light
+hminbn-h	H	!Ryumin-Light,Bold
+hminbn-v	V	!Ryumin-Light,Bold
+hgothrn-h	H	!GothicBBB-Medium
+hgothrn-v	V	!GothicBBB-Medium
+hgothbn-h	H	!GothicBBB-Medium,Bold
+hgothbn-v	V	!GothicBBB-Medium,Bold
+hgothebn-h	H	!GothicBBB-Medium,Bold
+hgothebn-v	V	!GothicBBB-Medium,Bold
+hmgothrn-h	H	!GothicBBB-Medium
+hmgothrn-v	V	!GothicBBB-Medium
+
+% CID
+otf-cjml-h	Identity-H	!Ryumin-Light
+otf-cjml-v	Identity-V	!Ryumin-Light
+otf-cjmr-h	Identity-H	!Ryumin-Light
+otf-cjmr-v	Identity-V	!Ryumin-Light
+otf-cjmb-h	Identity-H	!Ryumin-Light,Bold
+otf-cjmb-v	Identity-V	!Ryumin-Light,Bold
+otf-cjgr-h	Identity-H	!GothicBBB-Medium
+otf-cjgr-v	Identity-V	!GothicBBB-Medium
+otf-cjgb-h	Identity-H	!GothicBBB-Medium,Bold
+otf-cjgb-v	Identity-V	!GothicBBB-Medium,Bold
+otf-cjge-h	Identity-H	!GothicBBB-Medium,Bold
+otf-cjge-v	Identity-V	!GothicBBB-Medium,Bold
+otf-cjmgr-h	Identity-H	!GothicBBB-Medium
+otf-cjmgr-v	Identity-V	!GothicBBB-Medium
+
+% Unicode 90JIS
+otf-ujml-h	unicode	:0:NotoSerifCJK-Light.ttc -l jp90 %!DVIPSFB !Ryumin-Light-UniJIS-UTF16-H
+otf-ujml-v	unicode	:0:NotoSerifCJK-Light.ttc -w 1 -l jp90 %!DVIPSFB !Ryumin-Light-UniJIS-UTF16-V
+otf-ujmr-h	unicode	:0:NotoSerifCJK-Regular.ttc -l jp90 %!DVIPSFB !Ryumin-Light-UniJIS-UTF16-H
+otf-ujmr-v	unicode	:0:NotoSerifCJK-Regular.ttc -w 1 -l jp90 %!DVIPSFB !Ryumin-Light-UniJIS-UTF16-V
+otf-ujmb-h	unicode	:0:NotoSerifCJK-Bold.ttc -l jp90 %!DVIPSFB !Ryumin-Light,Bold-UniJIS-UTF16-H
+otf-ujmb-v	unicode	:0:NotoSerifCJK-Bold.ttc -w 1 -l jp90 %!DVIPSFB !Ryumin-Light,Bold-UniJIS-UTF16-V
+otf-ujgr-h	unicode	:0:NotoSansCJK-Regular.ttc -l jp90 %!DVIPSFB !GothicBBB-Medium-UniJIS-UTF16-H
+otf-ujgr-v	unicode	:0:NotoSansCJK-Regular.ttc -w 1 -l jp90 %!DVIPSFB !GothicBBB-Medium-UniJIS-UTF16-V
+otf-ujgb-h	unicode	:0:NotoSansCJK-Bold.ttc -l jp90 %!DVIPSFB !GothicBBB-Medium,Bold-UniJIS-UTF16-H
+otf-ujgb-v	unicode	:0:NotoSansCJK-Bold.ttc -w 1 -l jp90 %!DVIPSFB !GothicBBB-Medium,Bold-UniJIS-UTF16-V
+otf-ujge-h	unicode	:0:NotoSansCJK-Black.ttc -l jp90 %!DVIPSFB !GothicBBB-Medium,Bold-UniJIS-UTF16-H
+otf-ujge-v	unicode	:0:NotoSansCJK-Black.ttc -w 1 -l jp90 %!DVIPSFB !GothicBBB-Medium,Bold-UniJIS-UTF16-V
+otf-ujmgr-h	unicode	:0:NotoSansCJK-Medium.ttc -l jp90 %!DVIPSFB !GothicBBB-Medium-UniJIS-UTF16-H
+otf-ujmgr-v	unicode	:0:NotoSansCJK-Medium.ttc -w 1 -l jp90 %!DVIPSFB !GothicBBB-Medium-UniJIS-UTF16-V
+
+% Unicode JIS04
+otf-ujmln-h	unicode	:0:NotoSerifCJK-Light.ttc -l jp04 %!DVIPSFB !Ryumin-Light-UniJIS2004-UTF16-H
+otf-ujmln-v	unicode	:0:NotoSerifCJK-Light.ttc -w 1 -l jp04 %!DVIPSFB !Ryumin-Light-UniJIS2004-UTF16-V
+otf-ujmrn-h	unicode	:0:NotoSerifCJK-Regular.ttc -l jp04 %!DVIPSFB !Ryumin-Light-UniJIS2004-UTF16-H
+otf-ujmrn-v	unicode	:0:NotoSerifCJK-Regular.ttc -w 1 -l jp04 %!DVIPSFB !Ryumin-Light-UniJIS2004-UTF16-V
+otf-ujmbn-h	unicode	:0:NotoSerifCJK-Bold.ttc -l jp04 %!DVIPSFB !Ryumin-Light,Bold-UniJIS2004-UTF16-H
+otf-ujmbn-v	unicode	:0:NotoSerifCJK-Bold.ttc -w 1 -l jp04 %!DVIPSFB !Ryumin-Light,Bold-UniJIS2004-UTF16-V
+otf-ujgrn-h	unicode	:0:NotoSansCJK-Regular.ttc -l jp04 %!DVIPSFB !GothicBBB-Medium-UniJIS2004-UTF16-H
+otf-ujgrn-v	unicode	:0:NotoSansCJK-Regular.ttc -w 1 -l jp04 %!DVIPSFB !GothicBBB-Medium-UniJIS2004-UTF16-V
+otf-ujgbn-h	unicode	:0:NotoSansCJK-Bold.ttc -l jp04 %!DVIPSFB !GothicBBB-Medium,Bold-UniJIS2004-UTF16-H
+otf-ujgbn-v	unicode	:0:NotoSansCJK-Bold.ttc -w 1 -l jp04 %!DVIPSFB !GothicBBB-Medium,Bold-UniJIS2004-UTF16-V
+otf-ujgen-h	unicode	:0:NotoSansCJK-Black.ttc -l jp04 %!DVIPSFB !GothicBBB-Medium,Bold-UniJIS2004-UTF16-H
+otf-ujgen-v	unicode	:0:NotoSansCJK-Black.ttc -w 1 -l jp04 %!DVIPSFB !GothicBBB-Medium,Bold-UniJIS2004-UTF16-V
+otf-ujmgrn-h	unicode	:0:NotoSansCJK-Medium.ttc -l jp04 %!DVIPSFB !GothicBBB-Medium-UniJIS2004-UTF16-H
+otf-ujmgrn-v	unicode	:0:NotoSansCJK-Medium.ttc -w 1 -l jp04 %!DVIPSFB !GothicBBB-Medium-UniJIS2004-UTF16-V

--- a/noto-otc/otf-sc-noto-otc.map
+++ b/noto-otc/otf-sc-noto-otc.map
@@ -1,0 +1,12 @@
+
+% CID
+otf-ccmr-h	Identity-H	!STSong-Light
+otf-ccmr-v	Identity-V	!STSong-Light
+otf-ccgr-h	Identity-H	!STHeiti-Regular
+otf-ccgr-v	Identity-V	!STHeiti-Regular
+
+% Unicode
+otf-ucmr-h	unicode	:2:NotoSerifCJK-Regular.ttc %!DVIPSFB !STSong-Light-UniGB-UCS2-H
+otf-ucmr-v	unicode	:2:NotoSerifCJK-Regular.ttc -w 1 %!DVIPSFB !STSong-Light-UniGB-UCS2-V
+otf-ucgr-h	unicode	:2:NotoSansCJK-Medium.ttc %!DVIPSFB !STHeiti-Regular-UniGB-UCS2-H
+otf-ucgr-v	unicode	:2:NotoSansCJK-Medium.ttc -w 1 %!DVIPSFB !STHeiti-Regular-UniGB-UCS2-V

--- a/noto-otc/otf-tc-noto-otc.map
+++ b/noto-otc/otf-tc-noto-otc.map
@@ -1,0 +1,12 @@
+
+% CID
+otf-ctmr-h	Identity-H	!MSung-Light
+otf-ctmr-v	Identity-V	!MSung-Light
+otf-ctgr-h	Identity-H	!MHei-Medium
+otf-ctgr-v	Identity-V	!MHei-Medium
+
+% Unicode
+otf-utmr-h	unicode	:3:NotoSerifCJK-Regular.ttc %!DVIPSFB !MSung-Light-UniCNS-UCS2-H
+otf-utmr-v	unicode	:3:NotoSerifCJK-Regular.ttc -w 1 %!DVIPSFB !MSung-Light-UniCNS-UCS2-V
+otf-utgr-h	unicode	:3:NotoSansCJK-Medium.ttc %!DVIPSFB !MHei-Medium-UniCNS-UCS2-H
+otf-utgr-v	unicode	:3:NotoSansCJK-Medium.ttc -w 1 %!DVIPSFB !MHei-Medium-UniCNS-UCS2-V

--- a/noto-otc/otf-up-noto-otc.map
+++ b/noto-otc/otf-up-noto-otc.map
@@ -1,0 +1,32 @@
+
+% TEXT, 90JIS
+uphminl-h	unicode	:0:NotoSerifCJK-Light.ttc -l jp90 %!DVIPSFB !Ryumin-Light-UniJIS-UTF16-H
+uphminl-v	unicode	:0:NotoSerifCJK-Light.ttc -w 1 -l jp90 %!DVIPSFB !Ryumin-Light-UniJIS-UTF16-V
+uphminr-h	unicode	:0:NotoSerifCJK-Regular.ttc -l jp90 %!DVIPSFB !Ryumin-Light-UniJIS-UTF16-H
+uphminr-v	unicode	:0:NotoSerifCJK-Regular.ttc -w 1 -l jp90 %!DVIPSFB !Ryumin-Light-UniJIS-UTF16-V
+uphminb-h	unicode	:0:NotoSerifCJK-Bold.ttc -l jp90 %!DVIPSFB !Ryumin-Light,Bold-UniJIS-UTF16-H
+uphminb-v	unicode	:0:NotoSerifCJK-Bold.ttc -w 1 -l jp90 %!DVIPSFB !Ryumin-Light,Bold-UniJIS-UTF16-V
+uphgothr-h	unicode	:0:NotoSansCJK-Regular.ttc -l jp90 %!DVIPSFB !GothicBBB-Medium-UniJIS-UTF16-H
+uphgothr-v	unicode	:0:NotoSansCJK-Regular.ttc -w 1 -l jp90 %!DVIPSFB !GothicBBB-Medium-UniJIS-UTF16-V
+uphgothb-h	unicode	:0:NotoSansCJK-Bold.ttc -l jp90 %!DVIPSFB !GothicBBB-Medium,Bold-UniJIS-UTF16-H
+uphgothb-v	unicode	:0:NotoSansCJK-Bold.ttc -w 1 -l jp90 %!DVIPSFB !GothicBBB-Medium,Bold-UniJIS-UTF16-V
+uphgotheb-h	unicode	:0:NotoSansCJK-Black.ttc -l jp90 %!DVIPSFB !GothicBBB-Medium,Bold-UniJIS-UTF16-H
+uphgotheb-v	unicode	:0:NotoSansCJK-Black.ttc -w 1 -l jp90 %!DVIPSFB !GothicBBB-Medium,Bold-UniJIS-UTF16-V
+uphmgothr-h	unicode	:0:NotoSansCJK-Medium.ttc -l jp90 %!DVIPSFB !GothicBBB-Medium-UniJIS-UTF16-H
+uphmgothr-v	unicode	:0:NotoSansCJK-Medium.ttc -w 1 -l jp90 %!DVIPSFB !GothicBBB-Medium-UniJIS-UTF16-V
+
+% TEXT, JIS04
+uphminln-h	unicode	:0:NotoSerifCJK-Light.ttc -l jp04 %!DVIPSFB !Ryumin-Light-UniJIS2004-UTF16-H
+uphminln-v	unicode	:0:NotoSerifCJK-Light.ttc -w 1 -l jp04 %!DVIPSFB !Ryumin-Light-UniJIS2004-UTF16-V
+uphminrn-h	unicode	:0:NotoSerifCJK-Regular.ttc -l jp04 %!DVIPSFB !Ryumin-Light-UniJIS2004-UTF16-H
+uphminrn-v	unicode	:0:NotoSerifCJK-Regular.ttc -w 1 -l jp04 %!DVIPSFB !Ryumin-Light-UniJIS2004-UTF16-V
+uphminbn-h	unicode	:0:NotoSerifCJK-Bold.ttc -l jp04 %!DVIPSFB !Ryumin-Light,Bold-UniJIS2004-UTF16-H
+uphminbn-v	unicode	:0:NotoSerifCJK-Bold.ttc -w 1 -l jp04 %!DVIPSFB !Ryumin-Light,Bold-UniJIS2004-UTF16-V
+uphgothrn-h	unicode	:0:NotoSansCJK-Regular.ttc -l jp04 %!DVIPSFB !GothicBBB-Medium-UniJIS2004-UTF16-H
+uphgothrn-v	unicode	:0:NotoSansCJK-Regular.ttc -w 1 -l jp04 %!DVIPSFB !GothicBBB-Medium-UniJIS2004-UTF16-V
+uphgothbn-h	unicode	:0:NotoSansCJK-Bold.ttc -l jp04 %!DVIPSFB !GothicBBB-Medium,Bold-UniJIS2004-UTF16-H
+uphgothbn-v	unicode	:0:NotoSansCJK-Bold.ttc -w 1 -l jp04 %!DVIPSFB !GothicBBB-Medium,Bold-UniJIS2004-UTF16-V
+uphgothebn-h	unicode	:0:NotoSansCJK-Black.ttc -l jp04 %!DVIPSFB !GothicBBB-Medium,Bold-UniJIS2004-UTF16-H
+uphgothebn-v	unicode	:0:NotoSansCJK-Black.ttc -w 1 -l jp04 %!DVIPSFB !GothicBBB-Medium,Bold-UniJIS2004-UTF16-V
+uphmgothrn-h	unicode	:0:NotoSansCJK-Medium.ttc -l jp04 %!DVIPSFB !GothicBBB-Medium-UniJIS2004-UTF16-H
+uphmgothrn-v	unicode	:0:NotoSansCJK-Medium.ttc -w 1 -l jp04 %!DVIPSFB !GothicBBB-Medium-UniJIS2004-UTF16-V

--- a/noto-otc/ptex-noto-otc-04.map
+++ b/noto-otc/ptex-noto-otc-04.map
@@ -1,0 +1,4 @@
+rml	2004-H	!Ryumin-Light
+rmlv	2004-V	!Ryumin-Light
+gbm	2004-H	!GothicBBB-Medium
+gbmv	2004-V	!GothicBBB-Medium

--- a/noto-otc/ptex-noto-otc.map
+++ b/noto-otc/ptex-noto-otc.map
@@ -1,0 +1,4 @@
+rml	H	!Ryumin-Light
+rmlv	V	!Ryumin-Light
+gbm	H	!GothicBBB-Medium
+gbmv	V	!GothicBBB-Medium

--- a/noto-otc/uptex-ko-noto-otc.map
+++ b/noto-otc/uptex-ko-noto-otc.map
@@ -1,0 +1,4 @@
+uphysmjm-h	unicode	:1:NotoSerifCJK-Regular.ttc %!DVIPSFB !HYSMyeongJo-Medium-UniKS-UTF16-H
+uphysmjm-v	unicode	:1:NotoSerifCJK-Regular.ttc -w 1 %!DVIPSFB !HYSMyeongJo-Medium-UniKS-UTF16-V
+uphygt-h	unicode	:1:NotoSansCJK-Medium.ttc %!DVIPSFB !HYGoThic-Medium-UniKS-UTF16-H
+uphygt-v	unicode	:1:NotoSansCJK-Medium.ttc -w 1 %!DVIPSFB !HYGoThic-Medium-UniKS-UTF16-V

--- a/noto-otc/uptex-noto-otc-04.map
+++ b/noto-otc/uptex-noto-otc-04.map
@@ -1,0 +1,10 @@
+urml	unicode	:0:NotoSerifCJK-Regular.ttc -l jp04 %!DVIPSFB !Ryumin-Light-UniJIS2004-UTF16-H
+urmlv	unicode	:0:NotoSerifCJK-Regular.ttc -w 1 -l jp04 %!DVIPSFB !Ryumin-Light-UniJIS2004-UTF16-V
+ugbm	unicode	:0:NotoSansCJK-Medium.ttc -l jp04 %!DVIPSFB !GothicBBB-Medium-UniJIS2004-UTF16-H
+ugbmv	unicode	:0:NotoSansCJK-Medium.ttc -w 1 -l jp04 %!DVIPSFB !GothicBBB-Medium-UniJIS2004-UTF16-V
+uprml-h	unicode	:0:NotoSerifCJK-Regular.ttc -l jp04 %!DVIPSFB !Ryumin-Light-UniJIS2004-UTF16-H
+uprml-v	unicode	:0:NotoSerifCJK-Regular.ttc -w 1 -l jp04 %!DVIPSFB !Ryumin-Light-UniJIS2004-UTF16-V
+upgbm-h	unicode	:0:NotoSansCJK-Medium.ttc -l jp04 %!DVIPSFB !GothicBBB-Medium-UniJIS2004-UTF16-H
+upgbm-v	unicode	:0:NotoSansCJK-Medium.ttc -w 1 -l jp04 %!DVIPSFB !GothicBBB-Medium-UniJIS2004-UTF16-V
+uprml-hq	unicode	:0:NotoSerifCJK-Regular.ttc -l fwid %!DVIPSFB !Ryumin-Light-UniJIS-UCS2-H
+upgbm-hq	unicode	:0:NotoSansCJK-Medium.ttc -l fwid %!DVIPSFB !GothicBBB-Medium-UniJIS-UCS2-H

--- a/noto-otc/uptex-noto-otc.map
+++ b/noto-otc/uptex-noto-otc.map
@@ -1,0 +1,10 @@
+urml	unicode	:0:NotoSerifCJK-Regular.ttc -l jp90 %!DVIPSFB !Ryumin-Light-UniJIS-UTF16-H
+urmlv	unicode	:0:NotoSerifCJK-Regular.ttc -w 1 -l jp90 %!DVIPSFB !Ryumin-Light-UniJIS-UTF16-V
+ugbm	unicode	:0:NotoSansCJK-Medium.ttc -l jp90 %!DVIPSFB !GothicBBB-Medium-UniJIS-UTF16-H
+ugbmv	unicode	:0:NotoSansCJK-Medium.ttc -w 1 -l jp90 %!DVIPSFB !GothicBBB-Medium-UniJIS-UTF16-V
+uprml-h	unicode	:0:NotoSerifCJK-Regular.ttc -l jp90 %!DVIPSFB !Ryumin-Light-UniJIS-UTF16-H
+uprml-v	unicode	:0:NotoSerifCJK-Regular.ttc -w 1 -l jp90 %!DVIPSFB !Ryumin-Light-UniJIS-UTF16-V
+upgbm-h	unicode	:0:NotoSansCJK-Medium.ttc -l jp90 %!DVIPSFB !GothicBBB-Medium-UniJIS-UTF16-H
+upgbm-v	unicode	:0:NotoSansCJK-Medium.ttc -w 1 -l jp90 %!DVIPSFB !GothicBBB-Medium-UniJIS-UTF16-V
+uprml-hq	unicode	:0:NotoSerifCJK-Regular.ttc -l fwid %!DVIPSFB !Ryumin-Light-UniJIS-UCS2-H
+upgbm-hq	unicode	:0:NotoSansCJK-Medium.ttc -l fwid %!DVIPSFB !GothicBBB-Medium-UniJIS-UCS2-H

--- a/noto-otc/uptex-sc-noto-otc.map
+++ b/noto-otc/uptex-sc-noto-otc.map
@@ -1,0 +1,4 @@
+upstsl-h	unicode	:2:NotoSerifCJK-Regular.ttc %!DVIPSFB !STSong-Light-UniGB-UTF16-H
+upstsl-v	unicode	:2:NotoSerifCJK-Regular.ttc -w 1 %!DVIPSFB !STSong-Light-UniGB-UTF16-V
+upstht-h	unicode	:2:NotoSansCJK-Medium.ttc %!DVIPSFB !STHeiti-Regular-UniGB-UTF16-H
+upstht-v	unicode	:2:NotoSansCJK-Medium.ttc -w 1 %!DVIPSFB !STHeiti-Regular-UniGB-UTF16-V

--- a/noto-otc/uptex-tc-noto-otc.map
+++ b/noto-otc/uptex-tc-noto-otc.map
@@ -1,0 +1,4 @@
+upmsl-h	unicode	:3:NotoSerifCJK-Regular.ttc %!DVIPSFB !MSung-Light-UniCNS-UTF16-H
+upmsl-v	unicode	:3:NotoSerifCJK-Regular.ttc -w 1 %!DVIPSFB !MSung-Light-UniCNS-UTF16-V
+upmhm-h	unicode	:3:NotoSansCJK-Medium.ttc %!DVIPSFB !MHei-Medium-UniCNS-UTF16-H
+upmhm-v	unicode	:3:NotoSansCJK-Medium.ttc -w 1 %!DVIPSFB !MHei-Medium-UniCNS-UTF16-V

--- a/review-3.1/Dockerfile
+++ b/review-3.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:stretch-slim
 LABEL maintainer="vvakame@gmail.com"
 
 ENV REVIEW_VERSION 3.1.0
@@ -46,8 +46,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     npm install -g yarn
 
-# install noto font
-RUN apt-get update && apt-get -y install fonts-noto-cjk-extra
+# install noto font from backports
+RUN echo "deb http://ftp.jp.debian.org/debian/ stretch-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get -y install fonts-noto-cjk/stretch-backports fonts-noto-cjk-extra/stretch-backports
 
 ## install font map of noto for dvipdfmx
 COPY noto/ /usr/share/texlive/texmf-dist/fonts/map/dvipdfmx/ptex-fontmaps/noto/

--- a/review-3.1/Dockerfile
+++ b/review-3.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 LABEL maintainer="vvakame@gmail.com"
 
 ENV REVIEW_VERSION 3.1.0
@@ -46,9 +46,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     npm install -g yarn
 
-# install noto font from backports
-RUN echo "deb http://ftp.jp.debian.org/debian/ stretch-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get -y install fonts-noto-cjk/stretch-backports fonts-noto-cjk-extra/stretch-backports
+# install noto font
+RUN apt-get update && apt-get -y install fonts-noto-cjk-extra
 
 ## install font map of noto for dvipdfmx
 COPY noto/ /usr/share/texlive/texmf-dist/fonts/map/dvipdfmx/ptex-fontmaps/noto/


### PR DESCRIPTION
TeXLive 2018以降じゃないと困るケースが出てきそうなので、デフォルトおよびRe:VIEW 3.1について Debian 9 Stretch から Debian 10 Buster に更新するPRです。

現時点ではまだDebian Busterはリリース前なので、WIPにしておきます。
