### PR TITLE
imgmathを動作させるためのパッケージ追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
       texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern cm-super tex-gyre fonts-texgyre texlive-pictures texlive-plain-generic \
       ghostscript gsfonts \
       zip ruby-zip \
-      ruby-nokogiri mecab ruby-mecab mecab-ipadic-utf8 poppler-data \
+      ruby-nokogiri mecab ruby-mecab mecab-ipadic-utf8 poppler-utils poppler-data \
       graphviz gnuplot python-blockdiag python-aafigure \
       ruby-dev build-essential \
       mecab-jumandic- mecab-jumandic-utf8- && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,11 @@ RUN apt-get update && \
       texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern cm-super tex-gyre fonts-texgyre texlive-pictures texlive-plain-generic \
       ghostscript gsfonts \
       zip ruby-zip \
-      ruby-nokogiri mecab ruby-mecab mecab-ipadic-utf8 poppler-utils poppler-data \
+      ruby-nokogiri mecab ruby-mecab mecab-ipadic-utf8 poppler-data \
       graphviz gnuplot python-blockdiag python-aafigure \
       ruby-dev build-essential \
-      mecab-jumandic- mecab-jumandic-utf8- && \
+      mecab-jumandic- mecab-jumandic-utf8- \
+      texlive-extra-utils poppler-utils && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 ## if you want to use ipa font instead of noto font, use this settings


### PR DESCRIPTION
#43 の対応です。

poppler-utils入れれば解決だな!と思ったら、texlive-extra-utilsも必要でした…orz

これで総イメージは2.07GBとなっています。
