### PR TITLE
add 5.1 tag to ghcr

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,6 +32,7 @@ jobs:
           - "4.1"
           - "4.2"
           - "5.0"
+          - "5.1"
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
refs #56
docker hubと違って ghcr はここをﾁｮｲするだけでタグが増えるのでえらい。

cc/ @kmuto 