### PR TITLE
pandoc2review, pandocを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ ENV NODEJS_VERSION 14
 
 ENV HARANOAJI_VERSION 20210130
 
+ENV PANDOC_VERSION 2.12
+ENV PANDOC_DEB_VERSION 2.12-1
+
 ENV LANG en_US.UTF-8
 
 # setup
@@ -37,7 +40,8 @@ RUN apt-get update && \
 
 # setup Re:VIEW
 RUN gem install bundler rake --no-rdoc --no-ri && \
-    gem install review -v "$REVIEW_VERSION" --no-rdoc --no-ri
+    gem install review -v "$REVIEW_VERSION" --no-rdoc --no-ri && \
+    gem install pandoc2review --no-rdoc --no-ri
 #   gem install review-peg -v "$REVIEW_PEG_VERSION" --no-rdoc --no-ri
 
 # install node.js environment
@@ -78,6 +82,11 @@ COPY haranoaji/ /usr/share/texlive/texmf-dist/fonts/map/dvipdfmx/ptex-fontmaps/h
 
 ## use haranoaji for uplatex
 RUN texhash && kanji-config-updmap-sys haranoaji
+
+## install pandoc
+RUN curl -sL -o /tmp/pandoc.deb https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_DEB_VERSION}-amd64.deb && \
+    dpkg -i /tmp/pandoc.deb && \
+    rm /tmp/pandoc.deb
 
 ## set cache folder to work folder (disabled by default)
 # RUN mkdir -p /etc/texmf/texmf.d && echo "TEXMFVAR=/work/.texmf-var" > /etc/texmf/texmf.d/99local.cnf

--- a/review-5.1/Dockerfile
+++ b/review-5.1/Dockerfile
@@ -7,6 +7,9 @@ ENV NODEJS_VERSION 14
 
 ENV HARANOAJI_VERSION 20210130
 
+ENV PANDOC_VERSION 2.12
+ENV PANDOC_DEB_VERSION 2.12-1
+
 ENV LANG en_US.UTF-8
 
 # setup
@@ -37,7 +40,8 @@ RUN apt-get update && \
 
 # setup Re:VIEW
 RUN gem install bundler rake --no-rdoc --no-ri && \
-    gem install review -v "$REVIEW_VERSION" --no-rdoc --no-ri
+    gem install review -v "$REVIEW_VERSION" --no-rdoc --no-ri && \
+    gem install pandoc2review --no-rdoc --no-ri
 #   gem install review-peg -v "$REVIEW_PEG_VERSION" --no-rdoc --no-ri
 
 # install node.js environment
@@ -78,6 +82,11 @@ COPY haranoaji/ /usr/share/texlive/texmf-dist/fonts/map/dvipdfmx/ptex-fontmaps/h
 
 ## use haranoaji for uplatex
 RUN texhash && kanji-config-updmap-sys haranoaji
+
+## install pandoc
+RUN curl -sL -o /tmp/pandoc.deb https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_DEB_VERSION}-amd64.deb && \
+    dpkg -i /tmp/pandoc.deb && \
+    rm /tmp/pandoc.deb
 
 ## set cache folder to work folder (disabled by default)
 # RUN mkdir -p /etc/texmf/texmf.d && echo "TEXMFVAR=/work/.texmf-var" > /etc/texmf/texmf.d/99local.cnf


### PR DESCRIPTION
https://github.com/TechBooster/ReVIEW-Template/pull/71
と関連して、Markdown原稿をサポートするよう、pandoc2reviewとpandocをインストールします。
Debian公式のpandocはだいぶ古いので、Pandoc公式ダウンロードページから取るようにしています。

依存パッケージ的にもイメージの大きさはさほど変わらないはず。
機能としてはRe:VIEW 5.1以上でよいと思われるので、Dockerfile, 5.1/Dockerfileのみを変更しました。
